### PR TITLE
fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY --from=builder /app/target/release/bilibili-webhook /usr/local/bin/
 COPY log.yml .
 
 RUN apk add -qq --no-cache libc6-compat sqlite-dev python3 python3-dev py3-pip ffmpeg gcc libc-dev && \
-    pip3 install --no-cache-dir yutto --pre
+    pip3 install --no-cache-dir yutto --pre --break-system-packages
 
 RUN addgroup -g 1000 pi && adduser -D -s /bin/sh -u 1000 -G pi pi && chown -R pi:pi .
 


### PR DESCRIPTION
在部署的时候发现会报虚拟环境警告，按正常情况警告不应该停止，但是这个警告返回的是 code: 1 然后 build 会被中断，传递 --break-system-packages 参数来忽略限制即可正常 build。